### PR TITLE
feat(zed): Use Catppuccin theme for my main programs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,6 +17,26 @@
         "type": "github"
       }
     },
+    "catppuccin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1747519437,
+        "narHash": "sha256-uv9Wv59d+mckS2CkorOF484wp2G5TNGijdoBZ5RkAk0=",
+        "owner": "catppuccin",
+        "repo": "nix",
+        "rev": "3ba714046ee32373e88166e6e9474d6ae6a5b734",
+        "type": "github"
+      },
+      "original": {
+        "owner": "catppuccin",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "cl-nix-lite": {
       "locked": {
         "lastModified": 1728174978,
@@ -427,6 +447,7 @@
     },
     "root": {
       "inputs": {
+        "catppuccin": "catppuccin",
         "easy-hosts": "easy-hosts",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager",

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,11 @@
       url = "github:DuskSystems/nix-zed-extensions";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    catppuccin = {
+      url = "github:catppuccin/nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/hosts/macbook-pro/home/default.nix
+++ b/hosts/macbook-pro/home/default.nix
@@ -18,6 +18,8 @@
 
       # Adds zed-extensions to programs attrset
       zed-extensions.homeManagerModules.default
+
+      catppuccin.homeModules.catppuccin
     ];
   };
 }

--- a/hosts/macbook-pro/home/home.nix
+++ b/hosts/macbook-pro/home/home.nix
@@ -12,6 +12,9 @@
 
   programs.home-manager.enable = true; # Allow Home Manager to manage itself;
 
-  # Set theme flavor
-  catppuccin.flavor = "mocha";
+  # Set theme flavor and accent
+  catppuccin = {
+    flavor = "mocha";
+    accent = "blue";
+  };
 }

--- a/hosts/macbook-pro/home/home.nix
+++ b/hosts/macbook-pro/home/home.nix
@@ -11,4 +11,7 @@
   };
 
   programs.home-manager.enable = true; # Allow Home Manager to manage itself;
+
+  # Set theme flavor
+  catppuccin.flavor = "mocha";
 }

--- a/hosts/macbook-pro/home/programs/bat/default.nix
+++ b/hosts/macbook-pro/home/programs/bat/default.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     ./settings.nix
+    ./theme.nix
   ];
 
   programs.bat = {

--- a/hosts/macbook-pro/home/programs/bat/settings.nix
+++ b/hosts/macbook-pro/home/programs/bat/settings.nix
@@ -1,6 +1,4 @@
 { ... }:
 {
-  programs.bat.config = {
-    theme = "Sublime Snazzy";
-  };
+  programs.bat.config = { };
 }

--- a/hosts/macbook-pro/home/programs/bat/theme.nix
+++ b/hosts/macbook-pro/home/programs/bat/theme.nix
@@ -1,4 +1,4 @@
-{ ... }:
-{
+{ config, lib, ... }:
+lib.mkIf config.programs.bat.enable {
   catppuccin.bat.enable = true;
 }

--- a/hosts/macbook-pro/home/programs/bat/theme.nix
+++ b/hosts/macbook-pro/home/programs/bat/theme.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  catppuccin.bat.enable = true;
+}

--- a/hosts/macbook-pro/home/programs/btop/default.nix
+++ b/hosts/macbook-pro/home/programs/btop/default.nix
@@ -1,5 +1,9 @@
 { ... }:
 {
+  imports = [
+    ./theme.nix
+  ];
+
   programs.btop = {
     enable = true;
   };

--- a/hosts/macbook-pro/home/programs/btop/theme.nix
+++ b/hosts/macbook-pro/home/programs/btop/theme.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  catppuccin.btop.enable = true;
+}

--- a/hosts/macbook-pro/home/programs/btop/theme.nix
+++ b/hosts/macbook-pro/home/programs/btop/theme.nix
@@ -1,4 +1,4 @@
-{ ... }:
-{
+{ config, lib, ... }:
+lib.mkIf config.programs.btop.enable {
   catppuccin.btop.enable = true;
 }

--- a/hosts/macbook-pro/home/programs/ghostty/default.nix
+++ b/hosts/macbook-pro/home/programs/ghostty/default.nix
@@ -4,6 +4,7 @@
     ./fixes
     ./settings.nix
     ./keybind.nix
+    ./theme.nix
   ];
 
   programs.ghostty = {

--- a/hosts/macbook-pro/home/programs/ghostty/fixes/package.nix
+++ b/hosts/macbook-pro/home/programs/ghostty/fixes/package.nix
@@ -1,6 +1,11 @@
 # This module overrides Ghostty package for macOS, because nixpkgs have no official package for this platform
 
-{ pkgs, lib, ... }:
-lib.mkIf pkgs.stdenv.isDarwin {
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+lib.mkIf (config.programs.ghostty.enable && pkgs.stdenv.isDarwin) {
   programs.ghostty.package = pkgs.nur.repos.DimitarNestorov.ghostty;
 }

--- a/hosts/macbook-pro/home/programs/ghostty/settings.nix
+++ b/hosts/macbook-pro/home/programs/ghostty/settings.nix
@@ -10,7 +10,6 @@
 {
   programs.ghostty.settings = {
     auto-update = "off";
-    theme = "Snazzy";
 
     # Window size
     window-width = 90;

--- a/hosts/macbook-pro/home/programs/ghostty/theme.nix
+++ b/hosts/macbook-pro/home/programs/ghostty/theme.nix
@@ -1,0 +1,4 @@
+{ ... }:
+{
+  catppuccin.ghostty.enable = true;
+}

--- a/hosts/macbook-pro/home/programs/ghostty/theme.nix
+++ b/hosts/macbook-pro/home/programs/ghostty/theme.nix
@@ -1,4 +1,4 @@
-{ ... }:
-{
+{ config, lib, ... }:
+lib.mkIf config.programs.ghostty.enable {
   catppuccin.ghostty.enable = true;
 }

--- a/hosts/macbook-pro/home/programs/vscode/default.nix
+++ b/hosts/macbook-pro/home/programs/vscode/default.nix
@@ -3,8 +3,9 @@
 { ... }:
 {
   imports = [
-    ./settings.nix
     ./extensions.nix
+    ./settings.nix
+    ./theme.nix
   ];
 
   programs.vscode = {

--- a/hosts/macbook-pro/home/programs/vscode/extensions.nix
+++ b/hosts/macbook-pro/home/programs/vscode/extensions.nix
@@ -40,5 +40,6 @@
       "mads-hartmann.bash-ide-vscode"
       "redhat.vscode-yaml"
       "waderyan.gitblame"
+      "catppuccin.catppuccin-vsc-icons"
     ];
 }

--- a/hosts/macbook-pro/home/programs/vscode/settings.nix
+++ b/hosts/macbook-pro/home/programs/vscode/settings.nix
@@ -13,7 +13,6 @@
     "editor.stickyScroll.enabled" = false;
 
     # Workbench settings
-    "workbench.colorTheme" = "Night Owl (No Italics)";
     "workbench.startupEditor" = "none";
 
     # Nix IDE settings

--- a/hosts/macbook-pro/home/programs/vscode/theme.nix
+++ b/hosts/macbook-pro/home/programs/vscode/theme.nix
@@ -1,5 +1,5 @@
-{ ... }:
-{
+{ config, lib, ... }:
+lib.mkIf config.programs.vscode.enable {
   catppuccin.vscode = {
     enable = true;
 

--- a/hosts/macbook-pro/home/programs/vscode/theme.nix
+++ b/hosts/macbook-pro/home/programs/vscode/theme.nix
@@ -18,5 +18,6 @@
     "editor.semanticHighlighting.enabled" = true;
     "terminal.integrated.minimumContrastRatio" = 1;
     "window.titleBarStyle" = "custom";
+    "workbench.iconTheme" = "catppuccin-mocha";
   };
 }

--- a/hosts/macbook-pro/home/programs/vscode/theme.nix
+++ b/hosts/macbook-pro/home/programs/vscode/theme.nix
@@ -1,0 +1,22 @@
+{ ... }:
+{
+  catppuccin.vscode = {
+    enable = true;
+
+    accent = "blue";
+
+    settings = {
+      # Disable italics
+      italicKeywords = false;
+      italicComments = false;
+      workbenchMode = "flat";
+    };
+  };
+
+  # VSCode settings overrides according to this plugin's recommendations
+  programs.vscode.profiles.default.userSettings = {
+    "editor.semanticHighlighting.enabled" = true;
+    "terminal.integrated.minimumContrastRatio" = 1;
+    "window.titleBarStyle" = "custom";
+  };
+}

--- a/hosts/macbook-pro/home/programs/zed/default.nix
+++ b/hosts/macbook-pro/home/programs/zed/default.nix
@@ -1,8 +1,9 @@
 { pkgsUnstable, ... }:
 {
   imports = [
-    ./settings.nix
     ./extensions.nix
+    ./settings.nix
+    ./theme.nix
   ];
 
   programs.zed-editor = {

--- a/hosts/macbook-pro/home/programs/zed/extensions.nix
+++ b/hosts/macbook-pro/home/programs/zed/extensions.nix
@@ -13,8 +13,6 @@
       graphql
       svelte
       nginx
-      catppuccin
-      catppuccin-icons
     ];
   };
 }

--- a/hosts/macbook-pro/home/programs/zed/extensions.nix
+++ b/hosts/macbook-pro/home/programs/zed/extensions.nix
@@ -13,6 +13,8 @@
       graphql
       svelte
       nginx
+      catppuccin
+      catppuccin-icons
     ];
   };
 }

--- a/hosts/macbook-pro/home/programs/zed/settings.nix
+++ b/hosts/macbook-pro/home/programs/zed/settings.nix
@@ -39,18 +39,6 @@
     # Use the same size as VSCode
     tab_size = 2;
 
-    theme = {
-      mode = "system";
-      light = "Catppuccin Latte - No Italics";
-      dark = "Catppuccin Mocha - No Italics";
-    };
-
-    icon_theme = {
-      mode = "system";
-      light = "Catppuccin Latte";
-      dark = "Catppuccin Mocha";
-    };
-
     features = {
       copilot = false;
     };

--- a/hosts/macbook-pro/home/programs/zed/settings.nix
+++ b/hosts/macbook-pro/home/programs/zed/settings.nix
@@ -40,9 +40,15 @@
     tab_size = 2;
 
     theme = {
-      mode = "dark";
-      light = "One Light";
-      dark = "Halcyon";
+      mode = "system";
+      light = "Catppuccin Latte - No Italics";
+      dark = "Catppuccin Mocha - No Italics";
+    };
+
+    icon_theme = {
+      mode = "system";
+      light = "Catppuccin Latte";
+      dark = "Catppuccin Mocha";
     };
 
     features = {

--- a/hosts/macbook-pro/home/programs/zed/theme.nix
+++ b/hosts/macbook-pro/home/programs/zed/theme.nix
@@ -1,0 +1,43 @@
+# Custom catppuccin theme configutation module for zed based on https://github.com/catppuccin/nix/blob/3ba714046ee32373e88166e6e9474d6ae6a5b734/modules/home-manager/zed-editor.nix
+#
+# This module is not configurable and will be always enabled if Zed is enabled.
+# It re-implements catppuccin module linked above so I can utilize zed-extensions flake to manage icons.
+
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  inherit (config.catppuccin) sources;
+  inherit (lib) toUpper substring stringLength;
+
+  mkCapitalize = str: (toUpper (substring 0 1 str)) + (substring 1 (stringLength str) str);
+
+  cfg = config.catppuccin;
+  enable = config.programs.zed-editor.enable;
+
+  accent = if cfg.accent == "mauve" then "" else " (${cfg.accent})";
+  flavor = if cfg.flavor == "frappe" then "Frappé" else mkCapitalize cfg.flavor;
+in
+lib.mkIf enable {
+  programs.zed-editor.userSettings = {
+    theme = {
+      mode = "system";
+      light = "Catppuccin Latte" + accent + " - No Italics";
+      dark = "Catppuccin " + flavor + accent + " - No Italics";
+    };
+
+    icon_theme = {
+      mode = "system";
+      light = "Catppuccin Latte";
+      dark = "Catppuccin Mocha";
+    };
+  };
+
+  programs.zed-editor-extensions.packages = with pkgs.zed-extensions; [ catppuccin-icons ];
+
+  xdg.configFile."zed/themes/catppuccin.json".source =
+    "${sources.zed}/catppuccin-no-italics-${cfg.accent}.json";
+}


### PR DESCRIPTION
This PR adds [Catppuccin](https://catppuccin.com/) (Catppuccin Mocha flavor) for my main programs using their official [flake](https://github.com/catppuccin/nix) + some of my custom tweaks (for Zed).